### PR TITLE
ci(security): use takumi guard

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,3 +16,5 @@ jobs:
       id-token: write
       actions: read
       attestations: write
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,6 +7,9 @@ jobs:
     uses: ./.github/workflows/workflow_call_test.yaml
     permissions:
       contents: read
+      id-token: write
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
   status-check:
     runs-on: ubuntu-24.04
     if: always() && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled'))

--- a/.github/workflows/wc-test.yaml
+++ b/.github/workflows/wc-test.yaml
@@ -6,12 +6,17 @@ on:
       docker_is_changed:
         required: false
         type: boolean
+    secrets:
+      TAKUMI_GUARD_BOT_ID:
+        required: true
 
 jobs:
   test:
     timeout-minutes: 30
     runs-on: ubuntu-latest
-    permissions: {}
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -19,6 +24,11 @@ jobs:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
+
+      - uses: flatt-security/setup-takumi-guard-golang@2e3c7c40b538cd68b2ac483def12982ebc8bc02e # v1
+        with:
+          bot-id: ${{secrets.TAKUMI_GUARD_BOT_ID}}
+
       - uses: aquaproj/aqua-installer@11dd79b4e498d471a9385aa9fb7f62bb5f52a73c # v4.0.4
         with:
           aqua_version: v2.59.1

--- a/.github/workflows/workflow_call_test.yaml
+++ b/.github/workflows/workflow_call_test.yaml
@@ -1,6 +1,10 @@
 ---
 name: test (workflow_call)
-on: workflow_call
+on:
+  workflow_call:
+    secrets:
+      TAKUMI_GUARD_BOT_ID:
+        required: true
 permissions: {}
 jobs:
   path-filter:
@@ -29,4 +33,8 @@ jobs:
 
   test:
     uses: ./.github/workflows/wc-test.yaml
-    permissions: {}
+    permissions:
+      contents: read
+      id-token: write
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}


### PR DESCRIPTION
Introduce [takumi guard](https://github.com/flatt-security) (the Go variant) into the CI workflows to harden Go module downloads against supply-chain attacks.

## Changes

- `.github/workflows/wc-test.yaml` (reusable workflow that runs `golangci-lint run` and `go test`):
  - Declared a required `TAKUMI_GUARD_BOT_ID` secret under `on.workflow_call.secrets`.
  - Added the `flatt-security/setup-takumi-guard-golang@v1` step immediately after `actions/setup-go` and before `aqua-installer`/module-downloading steps.
  - Changed the `test` job's `permissions` from `{}` to `contents: read` + `id-token: write` (required by the setup step's OIDC).
- `.github/workflows/workflow_call_test.yaml` (reusable workflow):
  - Declared a required `TAKUMI_GUARD_BOT_ID` secret under `on.workflow_call.secrets`.
  - In the `test` job that calls `./.github/workflows/wc-test.yaml`, added `id-token: write` to `permissions` and passed `TAKUMI_GUARD_BOT_ID` via `secrets`.
- `.github/workflows/test.yaml` (pull_request entrypoint):
  - In the `test` job that calls `./.github/workflows/workflow_call_test.yaml`, added `id-token: write` to `permissions` and passed `TAKUMI_GUARD_BOT_ID` via `secrets`.
- `.github/workflows/release.yaml`:
  - Passed `TAKUMI_GUARD_BOT_ID` to the `go-release-workflow` call via a `secrets` block (the workflow ref was already pinned to v8.1.0, so no ref bump was needed).

The `TAKUMI_GUARD_BOT_ID` secret must be configured in the repository/organization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)