### PR TITLE
ci(security): use takumi guard for autofix

### DIFF
--- a/.github/workflows/autofix.yaml
+++ b/.github/workflows/autofix.yaml
@@ -5,9 +5,11 @@ permissions: {}
 jobs:
   autofix:
     runs-on: ubuntu-24.04
-    permissions: {}
+    permissions:
+      id-token: write
     timeout-minutes: 15
     steps:
-      - uses: suzuki-shunsuke/go-autofix-action@ba716cebb7767055bdde0e62bb91d715bde39ab2 # v0.1.12
+      - uses: suzuki-shunsuke/go-autofix-action@9a8682f2dc2a935fe2a2ac96deb03de2dfcb872e # v0.1.13
         with:
           aqua_version: v2.59.1
+          takumi_guard_bot_id: ${{secrets.TAKUMI_GUARD_BOT_ID}}


### PR DESCRIPTION
Enable takumi guard in the autofix workflow (go-autofix-action).

## Changes

- Bumped `go-autofix-action` v0.1.12 → v0.1.13.
- Added the `takumi_guard_bot_id` input to the autofix step.
- Added `id-token: write` permission to the autofix job.

The `TAKUMI_GUARD_BOT_ID` secret must be configured in the repository/organization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)